### PR TITLE
Added different symbols in the header for the different wallet checked in status

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import WalletBatchInfo from "./WalletBatchInfo";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-eth";
@@ -102,6 +103,7 @@ export const Header = () => {
         </ul>
       </div>
       <div className="navbar-end flex-grow mr-4">
+        <WalletBatchInfo />
         <RainbowKitCustomConnectButton />
         <FaucetButton />
       </div>

--- a/packages/nextjs/components/WalletBatchInfo.tsx
+++ b/packages/nextjs/components/WalletBatchInfo.tsx
@@ -26,12 +26,27 @@ export default function WalletBatchInfo() {
     <div className="flex">
       {isInAllowList ? (
         isCheckedIn ? (
-          <ShieldCheckIcon className="h-6" title="You have checked in successfully" />
+          <div
+            className="tooltip tooltip-bottom tooltip-primary"
+            data-tip="Wallet address is part of the current batch and has successfully checked-in!"
+          >
+            <ShieldCheckIcon className="h-6" />
+          </div>
         ) : (
-          <ShieldExclamationIcon className="h-6" title="You are in the batch but not checked in" />
+          <div
+            className="tooltip tooltip-bottom tooltip-primary"
+            data-tip="Wallet address is part of the current batch, but is yet to check in!"
+          >
+            <ShieldExclamationIcon className="h-6" />
+          </div>
         )
       ) : (
-        <LockClosedIcon className="h-6" title="You are not in the batch" />
+        <div
+          className="tooltip tooltip-bottom tooltip-primary"
+          data-tip="Wallet address is not part of the current batch!"
+        >
+          <LockClosedIcon className="h-6" />
+        </div>
       )}
     </div>
   );

--- a/packages/nextjs/components/WalletBatchInfo.tsx
+++ b/packages/nextjs/components/WalletBatchInfo.tsx
@@ -1,0 +1,40 @@
+import { zeroAddress } from "viem";
+import { useAccount } from "wagmi";
+import { LockClosedIcon, ShieldCheckIcon, ShieldExclamationIcon } from "@heroicons/react/24/solid";
+import { useScaffoldContractRead } from "~~/hooks/scaffold-eth";
+
+export default function WalletBatchInfo() {
+  const { address } = useAccount();
+
+  const { data: isInAllowList } = useScaffoldContractRead({
+    contractName: "BatchRegistry",
+    functionName: "allowList",
+    args: [address],
+  });
+  const { data: userContractAddress } = useScaffoldContractRead({
+    contractName: "BatchRegistry",
+    functionName: "yourContractAddress",
+    args: [address],
+  });
+  const isCheckedIn = userContractAddress && userContractAddress !== zeroAddress;
+
+  console.log({ isInAllowList, userContractAddress, isCheckedIn });
+
+  if (!address) {
+    return <></>;
+  }
+
+  return (
+    <div className="flex">
+      {isInAllowList ? (
+        isCheckedIn ? (
+          <ShieldCheckIcon className="h-6" title="You have checked in successfully" />
+        ) : (
+          <ShieldExclamationIcon className="h-6" title="You are in the batch but not checked in" />
+        )
+      ) : (
+        <LockClosedIcon className="h-6" title="You are not in the batch" />
+      )}
+    </div>
+  );
+}

--- a/packages/nextjs/components/WalletBatchInfo.tsx
+++ b/packages/nextjs/components/WalletBatchInfo.tsx
@@ -18,8 +18,6 @@ export default function WalletBatchInfo() {
   });
   const isCheckedIn = userContractAddress && userContractAddress !== zeroAddress;
 
-  console.log({ isInAllowList, userContractAddress, isCheckedIn });
-
   if (!address) {
     return <></>;
   }


### PR DESCRIPTION
## Description

https://github.com/BuidlGuidl/batch4.buidlguidl.com/assets/39233126/eb39ab90-905e-4f5b-8888-58271bcdfd3a

Added different symbols in the header for the different wallet checked in status.
- Lock Icon if the wallet is not in the batch (allowlist).
- Shield with exclamation if the wallet is in the batch but not checked in
- Shield with tick if the wallet is checked in
- no icon if no wallet is connected

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #4_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: buidlguidl.yashgoyal.eth
