### PR TITLE
adds builders banner

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import type { NextPage } from "next";
-import { BugAntIcon, CodeBracketIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { BugAntIcon, CodeBracketIcon } from "@heroicons/react/24/outline";
 import { CheckedInChart } from "~~/components/CheckedInChart";
 import { useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 
@@ -40,16 +40,6 @@ const Home: NextPage = () => {
                 Tinker with your smart contract using the{" "}
                 <Link href="/debug" passHref className="link">
                   Debug Contracts
-                </Link>{" "}
-                tab.
-              </p>
-            </div>
-            <div className="flex flex-col bg-base-100 px-10 py-10 text-center items-center max-w-xs rounded-3xl">
-              <MagnifyingGlassIcon className="h-8 w-8 fill-secondary" />
-              <p>
-                Explore your local transactions with the{" "}
-                <Link href="/blockexplorer" passHref className="link">
-                  Block Explorer
                 </Link>{" "}
                 tab.
               </p>

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import type { NextPage } from "next";
-import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { BugAntIcon, CodeBracketIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { CheckedInChart } from "~~/components/CheckedInChart";
 import { useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 
@@ -20,7 +20,6 @@ const Home: NextPage = () => {
             <span className="block text-2xl mb-2">Welcome to</span>
             <span className="block text-4xl font-bold">Batch 4</span>
           </h1>
-          <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
             {checkedInCountFetched ? (
@@ -51,6 +50,16 @@ const Home: NextPage = () => {
                 Explore your local transactions with the{" "}
                 <Link href="/blockexplorer" passHref className="link">
                   Block Explorer
+                </Link>{" "}
+                tab.
+              </p>
+            </div>
+            <div className="flex flex-col bg-base-100 px-10 py-10 text-center items-center max-w-xs rounded-3xl">
+              <CodeBracketIcon className="h-8 w-8 fill-secondary" />
+              <p>
+                Check out the Batch 4 builders in the{" "}
+                <Link href="/builders" passHref className="link">
+                  Builders
                 </Link>{" "}
                 tab.
               </p>


### PR DESCRIPTION
#6 

## Description

- Adds a banner on main page linking to the Builders tab.
<img width="1158" alt="image" src="https://github.com/BuidlGuidl/batch4.buidlguidl.com/assets/62973287/3300f2b4-9bcd-4206-a9fb-9b4e90fa8d3a">

## Additional Information

- [X] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
