### PR TITLE
add github stats chart at main page

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import Batch4RepoStatsChart from "../components/Batch4RepoStats";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { Batch4RepoStatsChart } from "~~/components/Batch4RepoStats";
 import { CheckedInChart } from "~~/components/CheckedInChart";
 import { useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Batch4RepoStatsChart from "../components/Batch4RepoStats";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import { CheckedInChart } from "~~/components/CheckedInChart";
@@ -30,9 +31,16 @@ const Home: NextPage = () => {
             )}
           </p>
         </div>
-        <div className="w-full max-w-[800px] mx-auto mt-8">
-          <CheckedInChart />
+
+        <div className="w-full max-w-5xl mx-auto mt-8 flex flex-row justify-between items-center gap-8">
+          <div style={{ flex: 1 }}>
+            <CheckedInChart />
+          </div>
+          <div style={{ flex: 1 }}>
+            <Batch4RepoStatsChart />
+          </div>
         </div>
+
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">
           <div className="flex justify-center items-center gap-12 flex-col sm:flex-row">
             <div className="flex flex-col bg-base-100 px-10 py-10 text-center items-center max-w-xs rounded-3xl">

--- a/packages/nextjs/components/Batch4RepoStats.tsx
+++ b/packages/nextjs/components/Batch4RepoStats.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { CategoryScale, Chart as ChartJS, LineElement, LinearScale, PointElement, Tooltip } from "chart.js";
+import { useTheme } from "next-themes";
+import { Line } from "react-chartjs-2";
+import twconfig from "~~/tailwind.config";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip);
+
+const Batch4RepoStatsChart = () => {
+  const [stats, setStats] = useState({
+    stars: 0,
+    forks: 0,
+    openIssues: 0,
+    pullRequests: 0,
+  });
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { theme } = useTheme();
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      setIsLoading(true);
+      const [repoInfo, pullRequests] = await Promise.all([
+        fetch("https://api.github.com/repos/BuidlGuidl/batch4.buidlguidl.com").then(res => res.json()),
+        fetch("https://api.github.com/repos/BuidlGuidl/batch4.buidlguidl.com/pulls?state=open").then(res => res.json()),
+      ]);
+
+      setStats({
+        stars: repoInfo.stargazers_count,
+        forks: repoInfo.forks_count,
+        openIssues: repoInfo.open_issues_count,
+        pullRequests: pullRequests.length,
+      });
+      setIsLoading(false);
+    };
+
+    fetchStats();
+  }, []);
+
+  const themeColor = (module: string): string => {
+    return theme === "light" ? twconfig.daisyui.themes[0].light[module] : twconfig.daisyui.themes[1].dark[module];
+  };
+
+  const data = {
+    labels: ["Stars", "Forks", "Open Issues", "Pull Requests"],
+    datasets: [
+      {
+        data: [stats.stars, stats.forks, stats.openIssues, stats.pullRequests],
+        pointBackgroundColor: themeColor("secondary-content"),
+        hoverBackgroundColor: themeColor("accent"),
+        borderColor: themeColor("accent"),
+        showLine: true,
+        tension: 0.1,
+      },
+    ],
+  };
+
+  if (isLoading) {
+    return <div className="skeleton w-full max-w-[800px] mx-auto p-8 rounded-3xl h-96"></div>;
+  }
+
+  return (
+    <div className="w-full max-w-[800px] mx-auto p-8 bg-base-100 rounded-3xl">
+      <h1 className="text-center text-xl">Batch 4 Repository Stats</h1>
+      <Line
+        data={data}
+        options={{
+          scales: {
+            x: {
+              ticks: {
+                color: themeColor("secondary-content"),
+              },
+            },
+            y: {
+              beginAtZero: true,
+              ticks: {
+                color: themeColor("secondary-content"),
+              },
+            },
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                label: context => {
+                  const label = context.dataset.label;
+                  const value = context.parsed.y;
+                  return `${label}: ${value}`;
+                },
+              },
+            },
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+export default Batch4RepoStatsChart;

--- a/packages/nextjs/components/Batch4RepoStats.tsx
+++ b/packages/nextjs/components/Batch4RepoStats.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { CategoryScale, Chart as ChartJS, LineElement, LinearScale, PointElement, Tooltip } from "chart.js";
+import { BarElement, CategoryScale, Chart as ChartJS, LinearScale, Tooltip } from "chart.js";
 import { useTheme } from "next-themes";
-import { Line } from "react-chartjs-2";
+import { Bar } from "react-chartjs-2";
 import twconfig from "~~/tailwind.config";
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip);
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip);
 
-const Batch4RepoStatsChart = () => {
+export const Batch4RepoStatsChart = () => {
   const [stats, setStats] = useState({
     stars: 0,
     forks: 0,
@@ -48,11 +48,9 @@ const Batch4RepoStatsChart = () => {
     datasets: [
       {
         data: [stats.stars, stats.forks, stats.openIssues, stats.pullRequests],
-        pointBackgroundColor: themeColor("secondary-content"),
+        backgroundColor: themeColor("secondary-content"),
         hoverBackgroundColor: themeColor("accent"),
         borderColor: themeColor("accent"),
-        showLine: true,
-        tension: 0.1,
       },
     ],
   };
@@ -64,17 +62,18 @@ const Batch4RepoStatsChart = () => {
   return (
     <div className="w-full max-w-[800px] mx-auto p-8 bg-base-100 rounded-3xl">
       <h1 className="text-center text-xl">Batch 4 Repository Stats</h1>
-      <Line
+      <Bar
         data={data}
         options={{
+          indexAxis: "y",
           scales: {
             x: {
+              beginAtZero: true,
               ticks: {
                 color: themeColor("secondary-content"),
               },
             },
             y: {
-              beginAtZero: true,
               ticks: {
                 color: themeColor("secondary-content"),
               },
@@ -84,7 +83,7 @@ const Batch4RepoStatsChart = () => {
             tooltip: {
               callbacks: {
                 label: context => {
-                  const value = context.parsed.y;
+                  const value = context.parsed.x;
                   return `${value}`;
                 },
               },
@@ -95,5 +94,3 @@ const Batch4RepoStatsChart = () => {
     </div>
   );
 };
-
-export default Batch4RepoStatsChart;

--- a/packages/nextjs/components/Batch4RepoStats.tsx
+++ b/packages/nextjs/components/Batch4RepoStats.tsx
@@ -84,9 +84,8 @@ const Batch4RepoStatsChart = () => {
             tooltip: {
               callbacks: {
                 label: context => {
-                  const label = context.dataset.label;
                   const value = context.parsed.y;
-                  return `${label}: ${value}`;
+                  return `${value}`;
                 },
               },
             },


### PR DESCRIPTION
#6 

## Description

Creates a batch 4 github stats chart for the main page, following the style of check in chart.

![image](https://github.com/BuidlGuidl/batch4.buidlguidl.com/assets/70733914/2d2c71b5-d019-4f54-a017-10b74eaca924)


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: 0xF3b64dD5AF39d8fF0c614F7637e339e31466c4C3
